### PR TITLE
Fix scale factor

### DIFF
--- a/sdpsensor.cpp
+++ b/sdpsensor.cpp
@@ -80,7 +80,7 @@ int SDPSensor::readSample()
 
   int16_t dp_raw   = (int16_t)data[0] << 8 | data[1];
   int16_t temp_raw = (int16_t)data[3] << 8 | data[4];
-  uint8_t dp_scale  = (int16_t)data[6] << 8 | data[7];
+  int16_t dp_scale  = (int16_t)data[6] << 8 | data[7];
 
   mDifferentialPressure = dp_raw / (float)dp_scale;
   mTemperature = temp_raw / 200.0;

--- a/sdpsensor.cpp
+++ b/sdpsensor.cpp
@@ -80,7 +80,7 @@ int SDPSensor::readSample()
 
   int16_t dp_raw   = (int16_t)data[0] << 8 | data[1];
   int16_t temp_raw = (int16_t)data[3] << 8 | data[4];
-  int8_t dp_scale  = (int16_t)data[7] << 8 | data[8];
+  uint8_t dp_scale  = (int16_t)data[6] << 8 | data[7];
 
   mDifferentialPressure = dp_raw / (float)dp_scale;
   mTemperature = temp_raw / 200.0;


### PR DESCRIPTION
Fixed scale read. Data was read from wrong elements of I2C data array and masked to a wrong type of variable.